### PR TITLE
Support for generic susbcriptions

### DIFF
--- a/src/main/Application/Application.csproj
+++ b/src/main/Application/Application.csproj
@@ -7,7 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ei8.Cortex.Subscriptions.Common" Version="0.1.0" />
+    <PackageReference Include="ei8.Cortex.Subscriptions.Common" Version="0.1.2" />
+    <PackageReference Include="ei8.Net.Http" Version="0.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/main/Application/Interface/Service/ISubscriptionApplicationService.cs
+++ b/src/main/Application/Interface/Service/ISubscriptionApplicationService.cs
@@ -1,8 +1,6 @@
 ﻿using ei8.Cortex.Subscriptions.Common;
 using ei8.Cortex.Subscriptions.Common.Receivers;
 using ei8.Cortex.Subscriptions.Domain.Model;
-using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace ei8.Cortex.Subscriptions.Application.Interface.Service
@@ -10,13 +8,6 @@ namespace ei8.Cortex.Subscriptions.Application.Interface.Service
     public interface ISubscriptionApplicationService
     {
         Task AddSubscriptionAsync(SubscriptionInfo subscriptionInfo, IReceiverInfo receiverInfo);
-
-        /// <summary>
-        /// TODO: Remove later for debugging only
-        /// </summary>
-        /// <param name="userId"></param>
-        /// <returns></returns>
-        Task<IList<Subscription>> GetAllByUserIdAsync(Guid userId);
 
         Task NotifySubscribers(AvatarUrlSnapshot avatarUrlSnapshot);
     }

--- a/src/main/Application/Interface/Service/ISubscriptionApplicationService.cs
+++ b/src/main/Application/Interface/Service/ISubscriptionApplicationService.cs
@@ -1,4 +1,5 @@
 ﻿using ei8.Cortex.Subscriptions.Common;
+using ei8.Cortex.Subscriptions.Common.Receivers;
 using ei8.Cortex.Subscriptions.Domain.Model;
 using System;
 using System.Collections.Generic;
@@ -8,7 +9,7 @@ namespace ei8.Cortex.Subscriptions.Application.Interface.Service
 {
     public interface ISubscriptionApplicationService
     {
-        Task AddSubscriptionForBrowserAsync(BrowserSubscriptionInfo subscriptionInfo);
+        Task AddSubscriptionAsync(SubscriptionInfo subscriptionInfo, IReceiverInfo receiverInfo);
 
         /// <summary>
         /// TODO: Remove later for debugging only

--- a/src/main/Application/Interface/Service/PushNotifications/IPushNotificationApplicationService.cs
+++ b/src/main/Application/Interface/Service/PushNotifications/IPushNotificationApplicationService.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace ei8.Cortex.Subscriptions.Application.Interface.Service.PushNotifications
+{
+    public interface IPushNotificationApplicationService
+    {
+        Task NotifyReceiversForUserAsync(Guid userNeuronId, string avatarUrl);
+    }
+}

--- a/src/main/Application/PushNotifications/WebPushNotificationApplicationService.cs
+++ b/src/main/Application/PushNotifications/WebPushNotificationApplicationService.cs
@@ -1,0 +1,60 @@
+﻿using ei8.Cortex.Subscriptions.Application.Interface.Service.PushNotifications;
+using ei8.Cortex.Subscriptions.Domain.Model;
+using ei8.Net.Http.Notifications;
+using ei8.Net.Http.Notifications.Interface;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+
+namespace ei8.Cortex.Subscriptions.Application.PushNotifications
+{
+    public class WebPushNotificationApplicationService : IPushNotificationApplicationService
+    {
+        private readonly IBrowserReceiverRepository repository;
+        private readonly IPushNotificationService<WebPushNotificationPayload, WebPushReceiver> pushNotificationService;
+        private readonly ILogger<WebPushNotificationApplicationService> logger;
+
+        public WebPushNotificationApplicationService(IBrowserReceiverRepository repository,
+            IPushNotificationService<WebPushNotificationPayload, WebPushReceiver> pushNotificationService,
+            ILogger<WebPushNotificationApplicationService> logger)
+        {
+            this.repository = repository;
+            this.pushNotificationService = pushNotificationService;
+            this.logger = logger;
+        }
+
+        public async Task NotifyReceiversForUserAsync(Guid userNeuronId, string avatarUrl)
+        {
+            var notification = new WebPushNotificationPayload()
+            {
+                Title = "Avatar update",
+                Body = $"Avatar changed: {avatarUrl}"
+            };
+
+            var receivers = await this.repository.GetByUserIdAsync(userNeuronId);
+
+            foreach (var r in receivers)
+            {
+                await this.TrySendWebNotification(notification, r);
+            }
+        }
+        private async Task TrySendWebNotification(WebPushNotificationPayload notification, BrowserReceiver receiver)
+        {
+            try
+            {
+                var pushReceiver = new WebPushReceiver()
+                {
+                    Endpoint = receiver.PushEndpoint,
+                    P256DH = receiver.PushP256DH,
+                    Auth = receiver.PushAuth
+                };
+
+                await this.pushNotificationService.SendAsync(notification, pushReceiver);
+            }
+            catch (Exception ex)
+            {
+                this.logger.LogError(ex, "Error sending push notification: {Message}", ex.Message);
+            }
+        }
+    }
+}

--- a/src/main/Application/SubscriptionApplicationService.cs
+++ b/src/main/Application/SubscriptionApplicationService.cs
@@ -36,7 +36,7 @@ namespace ei8.Cortex.Subscriptions.Application
 
         public async Task AddSubscriptionAsync(SubscriptionInfo subscriptionInfo, IReceiverInfo receiverInfo)
         {
-            var user = await this.userRepository.GetOrAddAsync(subscriptionInfo.UserId);
+            var user = await this.userRepository.GetOrAddAsync(subscriptionInfo.UserNeuronId);
             var avatarUrlSnapshot = await this.avatarUrlSnapshotRepository.GetOrAddAsync(subscriptionInfo.AvatarUrl);
 
             switch (receiverInfo)
@@ -61,7 +61,7 @@ namespace ei8.Cortex.Subscriptions.Application
             var subscription = new Subscription()
             {
                 AvatarUrlSnapshotId = avatarUrlSnapshot.Id,
-                UserId = user.UserNeuronId,
+                UserNeuronId = user.UserNeuronId,
                 Id = Guid.NewGuid()
             };
 
@@ -76,7 +76,7 @@ namespace ei8.Cortex.Subscriptions.Application
             {
                 foreach (var notificationService in this.notificationServices)
                 {
-                    await notificationService.NotifyReceiversForUserAsync(sub.UserId, avatarUrlSnapshot.Url);
+                    await notificationService.NotifyReceiversForUserAsync(sub.UserNeuronId, avatarUrlSnapshot.Url);
                 }
             }
         }

--- a/src/main/Application/SubscriptionApplicationService.cs
+++ b/src/main/Application/SubscriptionApplicationService.cs
@@ -68,14 +68,8 @@ namespace ei8.Cortex.Subscriptions.Application
             await this.subscriptionRepository.AddAsync(subscription);
         }
 
-        public async Task<IList<Subscription>> GetAllByUserIdAsync(Guid userId)
-        {
-            return await this.subscriptionRepository.GetAllByUserIdAsync(userId);  
-        }
-
         public async Task NotifySubscribers(AvatarUrlSnapshot avatarUrlSnapshot)
         {
-
             var subscriptions = await this.subscriptionRepository.GetAllByAvatarUrlSnapshotIdAsync(avatarUrlSnapshot.Id);
 
             foreach (var sub in subscriptions)

--- a/src/main/Domain.Model/Domain.Model.csproj
+++ b/src/main/Domain.Model/Domain.Model.csproj
@@ -6,8 +6,4 @@
     <RootNamespace>ei8.Cortex.Subscriptions.Domain.Model</RootNamespace>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="ei8.Net.Http" Version="0.1.0" />
-  </ItemGroup>
-
 </Project>

--- a/src/main/Domain.Model/Subscription.cs
+++ b/src/main/Domain.Model/Subscription.cs
@@ -7,7 +7,7 @@ namespace ei8.Cortex.Subscriptions.Domain.Model
         public Guid Id { get; set; }
         public SubscriptionMode Mode { get; set; } = SubscriptionMode.Once;
         public Guid AvatarUrlSnapshotId { get; set; }
-        public Guid UserId { get; set; }
+        public Guid UserNeuronId { get; set; }
     }
 
     public enum SubscriptionMode

--- a/src/main/Port.Adapter/IO/Persistence/SQLite/BrowserReceiverRepository.cs
+++ b/src/main/Port.Adapter/IO/Persistence/SQLite/BrowserReceiverRepository.cs
@@ -32,7 +32,7 @@ namespace ei8.Cortex.Subscriptions.Port.Adapter.IO.Persistence.SQLite
                 {
                     Id = receiver.Id,
                     Name = receiver.Name,
-                    UserId = receiver.User.UserNeuronId,
+                    UserNeuronId = receiver.User.UserNeuronId,
                     PushAuth = receiver.PushAuth,
                     PushEndpoint = receiver.PushEndpoint,
                     PushP256DH = receiver.PushP256DH,
@@ -51,7 +51,7 @@ namespace ei8.Cortex.Subscriptions.Port.Adapter.IO.Persistence.SQLite
             };
 
             var list = await this.connection.Table<BrowserReceiverModel>()
-                                            .Where(b => b.UserId == id)
+                                            .Where(b => b.UserNeuronId == id)
                                             .ToListAsync();
 
             return list.Select(b => new BrowserReceiver()

--- a/src/main/Port.Adapter/IO/Persistence/SQLite/Models/BrowserReceiverModel.cs
+++ b/src/main/Port.Adapter/IO/Persistence/SQLite/Models/BrowserReceiverModel.cs
@@ -11,7 +11,7 @@ namespace ei8.Cortex.Subscriptions.Port.Adapter.IO.Persistence.SQLite.Models
         public Guid Id { get; set; }
 
         [ForeignKey(typeof(UserModel))]
-        public Guid UserId { get; set; }
+        public Guid UserNeuronId { get; set; }
 
         public string Name { get; set; }
         public string PushEndpoint { get; set; }

--- a/src/main/Port.Adapter/IO/Persistence/SQLite/Models/SubscriptionModel.cs
+++ b/src/main/Port.Adapter/IO/Persistence/SQLite/Models/SubscriptionModel.cs
@@ -14,7 +14,7 @@ namespace ei8.Cortex.Subscriptions.Port.Adapter.IO.Persistence.SQLite.Models
         public Guid AvatarId { get; set; }
 
         [ForeignKey(typeof(UserModel))]
-        public Guid UserId { get; set; }
+        public Guid UserNeuronId { get; set; }
 
         [ManyToOne]
         public UserModel User { get; set; }

--- a/src/main/Port.Adapter/IO/Persistence/SQLite/SubscriptionRepository.cs
+++ b/src/main/Port.Adapter/IO/Persistence/SQLite/SubscriptionRepository.cs
@@ -22,14 +22,14 @@ namespace ei8.Cortex.Subscriptions.Port.Adapter.IO.Persistence.SQLite
         {
             // check if existing subscription for the user and avatar ID pair exist
             var existingSubscription = await this.connection.Table<SubscriptionModel>()
-                                                            .FirstOrDefaultAsync(s => s.AvatarId == subscription.AvatarUrlSnapshotId && s.UserId == subscription.UserNeuronId);
+                                                            .FirstOrDefaultAsync(s => s.AvatarId == subscription.AvatarUrlSnapshotId && s.UserNeuronId == subscription.UserNeuronId);
 
             if (existingSubscription == null)
             {
                 var model = new SubscriptionModel()
                 {
                     AvatarId = subscription.AvatarUrlSnapshotId,
-                    UserId = subscription.UserNeuronId,
+                    UserNeuronId = subscription.UserNeuronId,
                     Id = subscription.Id
                 };
 
@@ -46,7 +46,7 @@ namespace ei8.Cortex.Subscriptions.Port.Adapter.IO.Persistence.SQLite
             return subscriptions.Select(s => new Subscription()
             {
                 Id = s.Id,
-                UserNeuronId = s.UserId,
+                UserNeuronId = s.UserNeuronId,
                 AvatarUrlSnapshotId = s.AvatarId
             }).ToList();
         }
@@ -55,12 +55,12 @@ namespace ei8.Cortex.Subscriptions.Port.Adapter.IO.Persistence.SQLite
         {
             var subscriptions = (await this.connection.Table<SubscriptionModel>()
                                                       .ToListAsync())
-                                                      .Where(s => s.UserId == userId);
+                                                      .Where(s => s.UserNeuronId == userId);
 
             return subscriptions.Select(s => new Subscription()
             {
                 Id = s.Id,
-                UserNeuronId = s.UserId,
+                UserNeuronId = s.UserNeuronId,
                 AvatarUrlSnapshotId = s.AvatarId
             }).ToList();
         }

--- a/src/main/Port.Adapter/IO/Persistence/SQLite/SubscriptionRepository.cs
+++ b/src/main/Port.Adapter/IO/Persistence/SQLite/SubscriptionRepository.cs
@@ -22,14 +22,14 @@ namespace ei8.Cortex.Subscriptions.Port.Adapter.IO.Persistence.SQLite
         {
             // check if existing subscription for the user and avatar ID pair exist
             var existingSubscription = await this.connection.Table<SubscriptionModel>()
-                                                            .FirstOrDefaultAsync(s => s.AvatarId == subscription.AvatarUrlSnapshotId && s.UserId == subscription.UserId);
+                                                            .FirstOrDefaultAsync(s => s.AvatarId == subscription.AvatarUrlSnapshotId && s.UserId == subscription.UserNeuronId);
 
             if (existingSubscription == null)
             {
                 var model = new SubscriptionModel()
                 {
                     AvatarId = subscription.AvatarUrlSnapshotId,
-                    UserId = subscription.UserId,
+                    UserId = subscription.UserNeuronId,
                     Id = subscription.Id
                 };
 
@@ -46,7 +46,7 @@ namespace ei8.Cortex.Subscriptions.Port.Adapter.IO.Persistence.SQLite
             return subscriptions.Select(s => new Subscription()
             {
                 Id = s.Id,
-                UserId = s.UserId,
+                UserNeuronId = s.UserId,
                 AvatarUrlSnapshotId = s.AvatarId
             }).ToList();
         }
@@ -60,7 +60,7 @@ namespace ei8.Cortex.Subscriptions.Port.Adapter.IO.Persistence.SQLite
             return subscriptions.Select(s => new Subscription()
             {
                 Id = s.Id,
-                UserId = s.UserId,
+                UserNeuronId = s.UserId,
                 AvatarUrlSnapshotId = s.AvatarId
             }).ToList();
         }

--- a/src/main/Port.Adapter/In/Api/Program.cs
+++ b/src/main/Port.Adapter/In/Api/Program.cs
@@ -65,11 +65,4 @@ app.MapPost("/subscriptions/receivers/{receiverType}", async (string receiverTyp
     return Results.Ok();
 });
 
-// TODO: remove later. for debugging only
-app.MapGet("/subscriptions/{userNeuronId}", async (Guid userNeuronId, ISubscriptionApplicationService service) =>
-{
-    var subs = await service.GetAllByUserIdAsync(userNeuronId);
-    return Results.Ok(subs);
-});
-
 app.Run();

--- a/src/main/Port.Adapter/In/Api/Program.cs
+++ b/src/main/Port.Adapter/In/Api/Program.cs
@@ -13,15 +13,15 @@ using ei8.Net.Http.Notifications;
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
-builder.Services.AddTransient<ISettingsService, EnvironmentSettingsService>();
-builder.Services.AddTransient<IAvatarUrlSnapshotRepository, AvatarUrlSnapshotRepository>();
-builder.Services.AddTransient<IUserRepository, UserRepository>();
-builder.Services.AddTransient<IBrowserReceiverRepository, BrowserReceiverRepository>();
-builder.Services.AddTransient<ISubscriptionRepository, SubscriptionRepository>();
-builder.Services.AddTransient<ISubscriptionApplicationService, SubscriptionApplicationService>();
-builder.Services.AddTransient<IPollingApplicationService, PollingApplicationService>();
-builder.Services.AddTransient<IPushNotificationApplicationService, WebPushNotificationApplicationService>();
-builder.Services.AddTransient<PushNotificationSettings>(sp =>
+builder.Services.AddScoped<ISettingsService, EnvironmentSettingsService>();
+builder.Services.AddScoped<IAvatarUrlSnapshotRepository, AvatarUrlSnapshotRepository>();
+builder.Services.AddScoped<IUserRepository, UserRepository>();
+builder.Services.AddScoped<IBrowserReceiverRepository, BrowserReceiverRepository>();
+builder.Services.AddScoped<ISubscriptionRepository, SubscriptionRepository>();
+builder.Services.AddScoped<ISubscriptionApplicationService, SubscriptionApplicationService>();
+builder.Services.AddScoped<IPollingApplicationService, PollingApplicationService>();
+builder.Services.AddScoped<IPushNotificationApplicationService, WebPushNotificationApplicationService>();
+builder.Services.AddScoped<PushNotificationSettings>(sp =>
 {
     // inject push notification settings from environment variables
     // through the main settings object

--- a/src/main/Port.Adapter/In/Api/Program.cs
+++ b/src/main/Port.Adapter/In/Api/Program.cs
@@ -48,9 +48,16 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
-app.MapPost("/subscriptions", async (BrowserSubscriptionInfo request, ISubscriptionApplicationService service) =>
+app.MapPost("/subscriptions/receivers/{receiverType}", async (string receiverType, HttpRequest request, ISubscriptionApplicationService service) =>
 {
-    await service.AddSubscriptionForBrowserAsync(request);
+    switch (receiverType)
+    {
+        case "web":
+            var obj = await request.ReadFromJsonAsync<AddSubscriptionWebReceiverRequest>();
+            await service.AddSubscriptionAsync(obj.SubscriptionInfo, obj.ReceiverInfo);
+            break;
+    }
+
     return Results.Ok();
 });
 

--- a/src/main/Port.Adapter/In/Api/Program.cs
+++ b/src/main/Port.Adapter/In/Api/Program.cs
@@ -1,12 +1,14 @@
 using ei8.Cortex.Subscriptions.Application;
 using ei8.Cortex.Subscriptions.Application.Interface.Service;
+using ei8.Cortex.Subscriptions.Application.Interface.Service.PushNotifications;
+using ei8.Cortex.Subscriptions.Application.PushNotifications;
 using ei8.Cortex.Subscriptions.Common;
 using ei8.Cortex.Subscriptions.Domain.Model;
 using ei8.Cortex.Subscriptions.In.Api.BackgroundServices;
 using ei8.Cortex.Subscriptions.Port.Adapter.IO.Persistence.SQLite;
 using ei8.Cortex.Subscriptions.Port.Adapter.IO.Process.Services;
+using ei8.Net.Http;
 using ei8.Net.Http.Notifications;
-using ei8.Net.Http.PayloadHashing;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -18,14 +20,16 @@ builder.Services.AddTransient<IBrowserReceiverRepository, BrowserReceiverReposit
 builder.Services.AddTransient<ISubscriptionRepository, SubscriptionRepository>();
 builder.Services.AddTransient<ISubscriptionApplicationService, SubscriptionApplicationService>();
 builder.Services.AddTransient<IPollingApplicationService, PollingApplicationService>();
-builder.Services.AddTransient<IPayloadHashService, HttpPayloadHashService>();
-builder.Services.AddTransient<IPushNotificationService, PushNotificationService>(sp =>
+builder.Services.AddTransient<IPushNotificationApplicationService, WebPushNotificationApplicationService>();
+builder.Services.AddTransient<PushNotificationSettings>(sp =>
 {
     // inject push notification settings from environment variables
     // through the main settings object
     var settings = sp.GetService<ISettingsService>();
-    return new PushNotificationService(settings.PushSettings);
+    return settings.PushSettings;
 });
+
+builder.Services.AddEi8Http();
 
 builder.Services.AddHttpClient();
 


### PR DESCRIPTION
* Separate subscription info from receiver info
* Separate integration with [`ei8-net-http`](https://github.com/ei8/net-http) per receiver type
* Change `In` endpoint path, to accept the receiver type as part of the endpoint
* Use scoped service lifetimes to improve performance
* Remove test code